### PR TITLE
Switch to GModPatchTool and improve Linux validation

### DIFF
--- a/swamp_reconnect.py
+++ b/swamp_reconnect.py
@@ -44,45 +44,45 @@ else:
     PROCESS_NAMES = ["gmod", "hl2_linux", "hl2.sh", "garrysmod"]
     REQUIRED_CMDS = ["tcpdump", "pgrep", "xdg-open"]
 
-# Global variable to store the full path to the CEF patch executable
-GMOD_CEF_FIX_PATH = None
+# Global variable to store the full path to the patch tool executable
+GMOD_PATCH_TOOL_PATH = None
 
-# Extract the patch from a zip file and set GMOD_CEF_FIX_PATH
-def extract_gmod_cef_fix(zip_path, extract_to):
+# Extract the patch from a zip file and set GMOD_PATCH_TOOL_PATH
+def extract_gmod_patch_tool(zip_path, extract_to):
     try:
         with zipfile.ZipFile(zip_path, 'r') as zip_ref:
             zip_ref.extractall(extract_to)
     except Exception as e:
         log_message(f"⚠️ [ERROR] Failed to extract zip file: {e}")
         return None
-    gmod_cef_exe = None
-    gmod_cef_folder = None
+    gmod_patch_tool_exe = None
+    gmod_patch_tool_folder = None
     # Recursively search for the executable inside the extracted files
     for root, dirs, files in os.walk(extract_to):
         for file in files:
-            if file.lower().endswith(".exe") and "gmodcefcodecfix" in file.lower():
-                gmod_cef_exe = os.path.join(root, file)
-                gmod_cef_folder = root
+            if file.lower().endswith(".exe") and "gmodpatchtool" in file.lower():
+                gmod_patch_tool_exe = os.path.join(root, file)
+                gmod_patch_tool_folder = root
                 break
-        if gmod_cef_exe:
+        if gmod_patch_tool_exe:
             break
-    if gmod_cef_exe and gmod_cef_folder:
-        dest_folder = os.path.join(os.path.dirname(zip_path), "GModCEFCodecFix")
+    if gmod_patch_tool_exe and gmod_patch_tool_folder:
+        dest_folder = os.path.join(os.path.dirname(zip_path), "GModPatchTool")
         if os.path.exists(dest_folder):
             shutil.rmtree(dest_folder)
         try:
-            shutil.copytree(gmod_cef_folder, dest_folder)
+            shutil.copytree(gmod_patch_tool_folder, dest_folder)
         except Exception as e:
             log_message(f"⚠️ [ERROR] Failed to copy extracted folder: {e}")
             return None
-        exe_name = os.path.basename(gmod_cef_exe)
-        global GMOD_CEF_FIX_PATH
-        GMOD_CEF_FIX_PATH = os.path.join(dest_folder, exe_name)
+        exe_name = os.path.basename(gmod_patch_tool_exe)
+        global GMOD_PATCH_TOOL_PATH
+        GMOD_PATCH_TOOL_PATH = os.path.join(dest_folder, exe_name)
         try:
-            os.chmod(GMOD_CEF_FIX_PATH, 0o755)  # Ensure the file is executable
+            os.chmod(GMOD_PATCH_TOOL_PATH, 0o755)  # Ensure the file is executable
         except Exception as e:
             log_message(f"⚠️ [ERROR] Failed to set executable permission: {e}")
-        log_message(f"✅ [INFO] Extracted GModCEFCodecFix to: {dest_folder}")
+        log_message(f"✅ [INFO] Extracted GModPatchTool to: {dest_folder}")
         return dest_folder
     else:
         log_message("⚠️ [ERROR] No executable found in the extracted zip.")
@@ -342,20 +342,20 @@ def validate_and_restart_gmod():
         subprocess.run(["pkill", "-9", "gmod"],
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.DEVNULL)
-        subprocess.run(["steam", GMOD_VALIDATE_URI],
+        subprocess.run(["xdg-open", GMOD_VALIDATE_URI],
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.DEVNULL)
     failed_attempts = 0
     crash_attempts = 0
     time.sleep(45)  # Wait to ensure Steam has fully validated files
-    if not run_gmod_cef_fix():
-        log_message("⚠️ [ERROR] GModCEFCodecFix did not apply successfully after validation.")
+    if not run_gmod_patch_tool():
+        log_message("⚠️ [ERROR] GModPatchTool did not apply successfully after validation.")
 
 # Check GitHub for a newer version of the patch and update if needed
-def check_for_new_cef_fix():
-    global GMOD_CEF_FIX_PATH
+def check_for_new_patch_tool():
+    global GMOD_PATCH_TOOL_PATH
     try:
-        response = requests.get("https://api.github.com/repos/solsticegamestudios/GModCEFCodecFix/releases/latest", timeout=10)
+        response = requests.get("https://api.github.com/repos/solsticegamestudios/GModPatchTool/releases/latest", timeout=10)
     except Exception as e:
         log_message(f"⚠️ [ERROR] Exception while fetching remote release info: {e}")
         return
@@ -378,11 +378,11 @@ def check_for_new_cef_fix():
         log_message(f"⚠️ [ERROR] Failed to parse remote date: {e}")
         return
     debug_log(f"Remote patch creation date: {remote_date}")
-    if not GMOD_CEF_FIX_PATH or not os.path.exists(GMOD_CEF_FIX_PATH):
-        log_message(f"⚠️ [WARNING] Local patch file not found at {GMOD_CEF_FIX_PATH}.")
+    if not GMOD_PATCH_TOOL_PATH or not os.path.exists(GMOD_PATCH_TOOL_PATH):
+        log_message(f"⚠️ [WARNING] Local patch file not found at {GMOD_PATCH_TOOL_PATH}.")
         return
     try:
-        local_timestamp = os.path.getmtime(GMOD_CEF_FIX_PATH)
+        local_timestamp = os.path.getmtime(GMOD_PATCH_TOOL_PATH)
         local_date = datetime.fromtimestamp(local_timestamp)
     except Exception as e:
         log_message(f"⚠️ [ERROR] Could not get modification time for local patch: {e}")
@@ -393,18 +393,18 @@ def check_for_new_cef_fix():
         if os.name == 'nt':
             asset_url = None
             try:
-                response = requests.get("https://api.github.com/repos/solsticegamestudios/GModCEFCodecFix/releases/latest", timeout=10)
+                response = requests.get("https://api.github.com/repos/solsticegamestudios/GModPatchTool/releases/latest", timeout=10)
                 data = response.json()
                 assets = data.get("assets", [])
                 for asset in assets:
                     name = asset.get("name", "")
-                    if name.lower().endswith(".exe") and "gmodcefcodecfix" in name.lower():
+                    if name.lower().endswith(".exe") and "gmodpatchtool" in name.lower():
                         asset_url = asset.get("browser_download_url")
                         break
                 if asset_url is None:
                     for asset in assets:
                         name = asset.get("name", "")
-                        if name.lower().endswith(".zip") and "gmodcefcodecfix" in name.lower():
+                        if name.lower().endswith(".zip") and "gmodpatchtool" in name.lower():
                             asset_url = asset.get("browser_download_url")
                             break
             except Exception as e:
@@ -414,12 +414,12 @@ def check_for_new_cef_fix():
                 try:
                     r = requests.get(asset_url, timeout=10)
                     if r.status_code == 200:
-                        exe_path = os.path.join(os.path.dirname(GMOD_CEF_FIX_PATH), os.path.basename(asset_url))
+                        exe_path = os.path.join(os.path.dirname(GMOD_PATCH_TOOL_PATH), os.path.basename(asset_url))
                         with open(exe_path, "wb") as f:
                             f.write(r.content)
                         os.chmod(exe_path, 0o755)
-                        GMOD_CEF_FIX_PATH = exe_path
-                        log_message("✅ [INFO] Updated GModCEFCodecFix to the latest patch.")
+                        GMOD_PATCH_TOOL_PATH = exe_path
+                        log_message("✅ [INFO] Updated GModPatchTool to the latest patch.")
                     else:
                         log_message("⚠️ [ERROR] Failed to download the patch from GitHub.")
                 except Exception as e:
@@ -429,12 +429,12 @@ def check_for_new_cef_fix():
         else:
             asset_url = None
             try:
-                response = requests.get("https://api.github.com/repos/solsticegamestudios/GModCEFCodecFix/releases/latest", timeout=10)
+                response = requests.get("https://api.github.com/repos/solsticegamestudios/GModPatchTool/releases/latest", timeout=10)
                 data = response.json()
                 assets = data.get("assets", [])
                 for asset in assets:
                     name = asset.get("name", "")
-                    if "linux" in name.lower() and "gmodcefcodecfix" in name.lower():
+                    if "linux" in name.lower() and "gmodpatchtool" in name.lower():
                         asset_url = asset.get("browser_download_url")
                         break
             except Exception as e:
@@ -444,12 +444,12 @@ def check_for_new_cef_fix():
                 try:
                     r = requests.get(asset_url, timeout=10)
                     if r.status_code == 200:
-                        linux_path = os.path.join(os.path.dirname(GMOD_CEF_FIX_PATH), os.path.basename(asset_url))
+                        linux_path = os.path.join(os.path.dirname(GMOD_PATCH_TOOL_PATH), os.path.basename(asset_url))
                         with open(linux_path, "wb") as f:
                             f.write(r.content)
                         os.chmod(linux_path, 0o755)
-                        GMOD_CEF_FIX_PATH = linux_path
-                        log_message("✅ [INFO] Updated GModCEFCodecFix for Linux to the latest patch.")
+                        GMOD_PATCH_TOOL_PATH = linux_path
+                        log_message("✅ [INFO] Updated GModPatchTool for Linux to the latest patch.")
                         return
                     else:
                         log_message("⚠️ [ERROR] Failed to download the Linux patch from GitHub.")
@@ -460,27 +460,27 @@ def check_for_new_cef_fix():
     else:
         log_message(f"✅ [INFO] Local patch is up-to-date (remote: {remote_date}, local: {local_date}).")
 
-# Run the CEF patch using pexpect inside a bash shell to capture output and send responses automatically.
-def run_gmod_cef_fix():
-    log_message("🛠 [INFO] Running GModCEFCodecFix with pexpect...")
-    check_for_new_cef_fix()
-    if not GMOD_CEF_FIX_PATH or not os.path.exists(GMOD_CEF_FIX_PATH):
-        log_message(f"⚠️ [ERROR] GModCEFCodecFix not found at {GMOD_CEF_FIX_PATH}")
+# Run the patch tool using pexpect inside a bash shell to capture output and send responses automatically.
+def run_gmod_patch_tool():
+    log_message("🛠 [INFO] Running GModPatchTool with pexpect...")
+    check_for_new_patch_tool()
+    if not GMOD_PATCH_TOOL_PATH or not os.path.exists(GMOD_PATCH_TOOL_PATH):
+        log_message(f"⚠️ [ERROR] GModPatchTool not found at {GMOD_PATCH_TOOL_PATH}")
         return False
-    if not os.access(GMOD_CEF_FIX_PATH, os.X_OK):
-        log_message(f"⚠️ [ERROR] GModCEFCodecFix is not executable. Attempting to set executable permission.")
+    if not os.access(GMOD_PATCH_TOOL_PATH, os.X_OK):
+        log_message(f"⚠️ [ERROR] GModPatchTool is not executable. Attempting to set executable permission.")
         try:
-            os.chmod(GMOD_CEF_FIX_PATH, 0o755)
+            os.chmod(GMOD_PATCH_TOOL_PATH, 0o755)
         except Exception as e:
             log_message(f"⚠️ [ERROR] Failed to set executable permission: {e}")
             return False
     try:
         # Use bash to run the patcher, quoting the full absolute path to handle spaces
-        cmd = shlex.quote(GMOD_CEF_FIX_PATH)
+        cmd = shlex.quote(GMOD_PATCH_TOOL_PATH)
         child = pexpect.spawn("/bin/bash", ["-c", cmd], timeout=180)
         child.logfile = sys.stdout.buffer
         # Wait for the success message from the patcher
-        child.expect("CEFCodecFix applied successfully!", timeout=180)
+        child.expect("Patch applied successfully", timeout=180)
         # If the patcher then prompts for launching GMod, send "n"
         try:
             child.expect("Do you want to Launch Garry's Mod now\\?", timeout=30)
@@ -490,19 +490,19 @@ def run_gmod_cef_fix():
         output = child.before.decode() if hasattr(child.before, "decode") else child.before
         ansi_escape = re.compile(r'\x1B[@-_][0-?]*[ -/]*[@-~]')
         cleaned_output = ansi_escape.sub('', output)
-        log_message("✅ [INFO] GModCEFCodecFix applied successfully (pexpect).")
+        log_message("✅ [INFO] GModPatchTool applied successfully (pexpect).")
         log_message(f"Output: {cleaned_output}")
         return True
     except pexpect.TIMEOUT:
-        log_message("⚠️ [ERROR] GModCEFCodecFix timed out in pexpect mode.")
+        log_message("⚠️ [ERROR] GModPatchTool timed out in pexpect mode.")
         return False
     except Exception as e:
         log_message(f"⚠️ [ERROR] Exception in pexpect patch run: {e}")
         return False
 
 # Search common directories for the patch; download it if not found
-def auto_configure_gmod_cef_path():
-    global GMOD_CEF_FIX_PATH
+def auto_configure_gmod_patch_tool_path():
+    global GMOD_PATCH_TOOL_PATH
     search_dirs = []
     home = os.path.expanduser("~")
     for folder in ["Documents", "Desktop", "Downloads"]:
@@ -510,9 +510,9 @@ def auto_configure_gmod_cef_path():
         if os.path.isdir(dir_path):
             search_dirs.append(dir_path)
     if os.name == 'nt':
-        patterns = [("GModCEFCodecFix", ".exe"), ("GModCEFCodecFix", ".zip")]
+        patterns = [("GModPatchTool", ".exe"), ("GModPatchTool", ".zip")]
     else:
-        patterns = [("GModCEFCodecFix-Linux", "")]
+        patterns = [("GModPatchTool-Linux", "")]
     for d in search_dirs:
         for root, _, files in os.walk(d):
             for file in files:
@@ -520,27 +520,27 @@ def auto_configure_gmod_cef_path():
                     if file.startswith(prefix) and file.endswith(ext):
                         candidate = os.path.join(root, file)
                         if os.name == 'nt' and ext == ".zip":
-                            extract_dir = os.path.join(root, "GModCEFCodecFix_extracted")
+                            extract_dir = os.path.join(root, "GModPatchTool_extracted")
                             os.makedirs(extract_dir, exist_ok=True)
                             try:
-                                extract_gmod_cef_fix(candidate, extract_dir)
-                                return GMOD_CEF_FIX_PATH
+                                extract_gmod_patch_tool(candidate, extract_dir)
+                                return GMOD_PATCH_TOOL_PATH
                             except Exception as e:
                                 log_message(f"⚠️ [ERROR] Failed to extract zip: {e}")
                         else:
-                            GMOD_CEF_FIX_PATH = candidate
-                            log_message(f"Found GModCEFCodecFix at: {GMOD_CEF_FIX_PATH}")
-                            return GMOD_CEF_FIX_PATH
-    log_message("GModCEFCodecFix not found in common directories. Downloading latest patch...")
-    download_latest_gmod_cef_fix()
-    return GMOD_CEF_FIX_PATH
+                            GMOD_PATCH_TOOL_PATH = candidate
+                            log_message(f"Found GModPatchTool at: {GMOD_PATCH_TOOL_PATH}")
+                            return GMOD_PATCH_TOOL_PATH
+    log_message("GModPatchTool not found in common directories. Downloading latest patch...")
+    download_latest_gmod_patch_tool()
+    return GMOD_PATCH_TOOL_PATH
 
 # Download the latest patch from GitHub if not available locally
-def download_latest_gmod_cef_fix():
-    global GMOD_CEF_FIX_PATH
+def download_latest_gmod_patch_tool():
+    global GMOD_PATCH_TOOL_PATH
     download_dir = os.path.dirname(os.path.realpath(__file__))
     try:
-        response = requests.get("https://api.github.com/repos/solsticegamestudios/GModCEFCodecFix/releases/latest", timeout=10)
+        response = requests.get("https://api.github.com/repos/solsticegamestudios/GModPatchTool/releases/latest", timeout=10)
     except Exception as e:
         log_message(f"⚠️ [ERROR] Exception while fetching release info from GitHub: {e}")
         return
@@ -558,10 +558,10 @@ def download_latest_gmod_cef_fix():
         zip_asset = None
         for asset in assets:
             name = asset.get("name", "")
-            if name.lower().endswith(".exe") and "gmodcefcodecfix" in name.lower():
+            if name.lower().endswith(".exe") and "gmodpatchtool" in name.lower():
                 exe_asset = asset
                 break
-            elif name.lower().endswith(".zip") and "gmodcefcodecfix" in name.lower():
+            elif name.lower().endswith(".zip") and "gmodpatchtool" in name.lower():
                 zip_asset = asset
         if exe_asset:
             url = exe_asset.get("browser_download_url")
@@ -579,7 +579,7 @@ def download_latest_gmod_cef_fix():
                     os.chmod(exe_path, 0o755)
                 except Exception as e:
                     log_message(f"⚠️ [ERROR] Failed to set executable permission: {e}")
-                GMOD_CEF_FIX_PATH = exe_path
+                GMOD_PATCH_TOOL_PATH = exe_path
                 log_message("✅ [INFO] Downloaded latest patch (Windows).")
                 return
             else:
@@ -596,9 +596,9 @@ def download_latest_gmod_cef_fix():
             if r.status_code == 200:
                 with open(zip_path, "wb") as f:
                     f.write(r.content)
-                extract_dir = os.path.join(download_dir, "GModCEFCodecFix_extracted")
+                extract_dir = os.path.join(download_dir, "GModPatchTool_extracted")
                 os.makedirs(extract_dir, exist_ok=True)
-                extract_gmod_cef_fix(zip_path, extract_dir)
+                extract_gmod_patch_tool(zip_path, extract_dir)
                 return
             else:
                 log_message("⚠️ [ERROR] Failed to download the zip patch.")
@@ -608,7 +608,7 @@ def download_latest_gmod_cef_fix():
         linux_asset = None
         for asset in assets:
             name = asset.get("name", "")
-            if "linux" in name.lower() and "gmodcefcodecfix" in name.lower():
+            if "linux" in name.lower() and "gmodpatchtool" in name.lower():
                 linux_asset = asset
                 break
         if linux_asset:
@@ -627,7 +627,7 @@ def download_latest_gmod_cef_fix():
                     os.chmod(linux_path, 0o755)
                 except Exception as e:
                     log_message(f"⚠️ [ERROR] Failed to set executable permission: {e}")
-                GMOD_CEF_FIX_PATH = linux_path
+                GMOD_PATCH_TOOL_PATH = linux_path
                 log_message("✅ [INFO] Downloaded latest patch (Linux).")
                 return
             else:
@@ -639,7 +639,7 @@ def download_latest_gmod_cef_fix():
 # This loop will only fetch the server IP if GMod is not connected.
 def main():
     global server_ip, failed_attempts, crash_attempts
-    auto_configure_gmod_cef_path()
+    auto_configure_gmod_patch_tool_path()
     check_dependencies()
     while True:
         try:


### PR DESCRIPTION
## Summary
- replace legacy GModCEFCodecFix support with GModPatchTool
- use `xdg-open` for Steam validation on Linux instead of the `steam` CLI

## Testing
- `python -m py_compile swamp_reconnect.py`


------
https://chatgpt.com/codex/tasks/task_e_68a141005a64832eb5d1f74da49ee004