### PR TITLE
Add workflow to build Windows executable

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -1,0 +1,32 @@
+name: Build Windows Executable
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+      - name: Run checks
+        run: |
+          python -m py_compile swamp_reconnect.py
+      - name: Build executable
+        run: |
+          pyinstaller --onefile swamp_reconnect.py
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: swamp_reconnect
+          path: dist/swamp_reconnect.exe


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that builds a Windows executable using PyInstaller

## Testing
- `python -m py_compile swamp_reconnect.py`


------
https://chatgpt.com/codex/tasks/task_e_68a15e7b90bc832eb4c8f2b777c2c95a